### PR TITLE
fix(examples): add security contexts to example deployments

### DIFF
--- a/examples/deployment-with-headwind.yaml
+++ b/examples/deployment-with-headwind.yaml
@@ -25,11 +25,17 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: nginx
         image: nginx:1.25.0
         ports:
         - containerPort: 80
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -50,11 +56,17 @@ spec:
       labels:
         app: redis
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: redis
         image: redis:7.2.0
         ports:
         - containerPort: 6379
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -76,8 +88,14 @@ spec:
       labels:
         app: my-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: app
         image: myregistry.com/my-app:v1.0.0-stable
         ports:
         - containerPort: 8080
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Fixes Semgrep SAST security findings by adding proper security contexts to all example Kubernetes deployments.

## Changes

Added security contexts to all three example deployments (nginx, redis, app):

### Pod-level security context:
```yaml
securityContext:
  runAsNonRoot: true
  runAsUser: 1000
```

### Container-level security context:
```yaml
securityContext:
  readOnlyRootFilesystem: true
  allowPrivilegeEscalation: false
```

## Security Benefits

1. **runAsNonRoot**: Prevents containers from running as root user, limiting damage from privilege escalation attacks
2. **readOnlyRootFilesystem**: Prevents malicious applications from downloading/modifying container files
3. **allowPrivilegeEscalation**: Blocks privilege escalation within the container

## Test Plan

- [x] Updated all 3 deployments in `examples/deployment-with-headwind.yaml`
- [x] Validated YAML syntax
- [ ] Semgrep SAST scan passes

## Semgrep Findings Resolved

- ✅ `yaml.kubernetes.security.run-as-non-root.run-as-non-root`
- ✅ `yaml.kubernetes.security.writable-filesystem-container.writable-filesystem-container`

## Related Issues

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)