### PR TITLE
fix: homepage should redirect to /docs not /docs/intro

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -3,10 +3,10 @@ import Layout from '@theme/Layout';
 
 export default function Home() {
   useEffect(() => {
-    // Redirect to the introduction page immediately
+    // Redirect to the documentation root immediately
     // Using window.location.replace for better compatibility with GitHub Pages
     if (typeof window !== 'undefined') {
-      window.location.replace('/docs/intro');
+      window.location.replace('/docs');
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes the homepage redirect URL to point to the correct documentation root.

## Problem

Homepage was redirecting to `/docs/intro` which doesn't exist, causing a 404 error.

**Current Behavior:**
- User visits https://headwind.sh
- Redirects to https://headwind.sh/docs/intro
- Shows 404 / Page Not Found error

## Solution

Changed redirect URL from `/docs/intro` to `/docs`.

**New Behavior:**
- User visits https://headwind.sh
- Redirects to https://headwind.sh/docs
- Loads documentation successfully

## Changes

### `docs/src/pages/index.tsx`

```diff
- window.location.replace('/docs/intro');
+ window.location.replace('/docs');
```

Also updated comment to reflect the change:
```diff
- // Redirect to the introduction page immediately
+ // Redirect to the documentation root immediately
```

## Testing

- ✅ Build succeeds: `npm run build`
- ✅ Pre-commit docs-build hook passes
- ✅ Redirect URL changed to `/docs`

## Impact

Users visiting headwind.sh will now be properly redirected to the documentation instead of seeing a 404 error.

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>