### PR TITLE
docs: add CI/CD status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Headwind
 
+[![CI](https://github.com/headwind-sh/headwind/actions/workflows/ci.yml/badge.svg)](https://github.com/headwind-sh/headwind/actions/workflows/ci.yml)
+[![Security](https://github.com/headwind-sh/headwind/actions/workflows/security.yml/badge.svg)](https://github.com/headwind-sh/headwind/actions/workflows/security.yml)
+[![Release](https://github.com/headwind-sh/headwind/actions/workflows/release.yml/badge.svg)](https://github.com/headwind-sh/headwind/actions/workflows/release.yml)
+[![Documentation](https://github.com/headwind-sh/headwind/actions/workflows/deploy-docs.yml/badge.svg)](https://github.com/headwind-sh/headwind/actions/workflows/deploy-docs.yml)
+
 A Kubernetes operator for automating workload updates based on container image changes, written in Rust.
 
 Headwind monitors container registries and automatically updates your Kubernetes workloads when new images are available, with intelligent semantic versioning policies and approval workflows.


### PR DESCRIPTION
## Summary

This PR adds GitHub Actions workflow status badges to the README, completing the final requirement of issue #65. The comprehensive CI/CD pipeline was already in place; this PR simply adds visibility through status badges.

## Changes

Added four status badges to the top of README.md:
- **CI Badge**: Shows status of test suite, clippy, formatting, compilation
- **Security Badge**: Shows status of dependency audits, secret scanning, SAST
- **Release Badge**: Shows status of automated releases and Docker builds
- **Documentation Badge**: Shows status of Docusaurus site deployment

All badges link directly to their respective GitHub Actions workflow pages.

## CI/CD Pipeline Already in Place

The workflows referenced by these badges provide comprehensive automation:

### CI Workflow (`.github/workflows/ci.yml`)
✅ **Format checking** - rustfmt validation
✅ **Linting** - clippy with warnings as errors
✅ **Test suite** - stable + nightly on ubuntu + macos
✅ **Compilation checks** - debug + release builds
✅ **Security audit** - cargo-audit for vulnerabilities
✅ **Unused dependencies** - cargo-udeps check
✅ **Code coverage** - cargo-tarpaulin on main branch
✅ **Documentation** - cargo doc build verification
✅ **Docker build** - image build validation
✅ **Kubernetes manifests** - kubeconform validation

### Security Workflow (`.github/workflows/security.yml`)
✅ **Daily security scans** - scheduled at 00:00 UTC
✅ **Cargo audit** - dependency vulnerability scanning
✅ **Secret scanning** - Gitleaks for exposed secrets
✅ **SAST** - Semgrep static analysis (security, rust, dockerfile, kubernetes rules)
✅ **Supply chain** - cargo-vet for dependency auditing

### Release Workflow (`.github/workflows/release.yml`)
✅ **Multi-platform binaries** - linux-amd64, linux-arm64, darwin-amd64, darwin-arm64
✅ **Multi-arch Docker** - linux/amd64, linux/arm64 with QEMU
✅ **Docker registries** - Docker Hub + ghcr.io
✅ **GitHub releases** - Automatic release creation on tags
✅ **crates.io** - Automatic publishing to Rust package registry

### Documentation Workflow (`.github/workflows/deploy-docs.yml`)
✅ **Docusaurus build** - Automated documentation site building
✅ **GitHub Pages** - Deployment to https://headwind.sh (or configured domain)

## Issue #65 Acceptance Criteria

From the original issue, all criteria are now met:

- [x] ✅ All tests run on every PR (ci.yml)
- [x] ✅ Docker images published on tag push (release.yml)
- [x] ✅ GitHub releases created automatically (release.yml)
- [x] ✅ Security scans run weekly (security.yml - daily actually)
- [x] ✅ **Status badges visible in README** (this PR)
- [x] ✅ Documentation updated (workflows exist with inline comments)

## Screenshots

Status badges will appear at the top of the README:

```markdown
[![CI](https://github.com/headwind-sh/headwind/actions/workflows/ci.yml/badge.svg)](...)
[![Security](https://github.com/headwind-sh/headwind/actions/workflows/security.yml/badge.svg)](...)
[![Release](https://github.com/headwind-sh/headwind/actions/workflows/release.yml/badge.svg)](...)
[![Documentation](https://github.com/headwind-sh/headwind/actions/workflows/deploy-docs.yml/badge.svg)](...)
```

## Additional Updates

Also updated **issue #18** (epic) with detailed testing requirements breakdown:
- Added checkboxes for completed core features
- Expanded "Testing Requirements" section with specific gaps:
  - Web UI unit tests (routes, auth, metrics client)
  - Web UI integration tests
  - System tests (multi-registry, load testing)
- Updated "Current State" to reflect Web UI completion
- Updated "Related Issues" with completed items

## Related Issues

Closes #65

Updates #18 with detailed testing requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>