### PR TITLE
refactor: Docker build to use pre-built release binaries from GitHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,9 +15,40 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Wait for release workflow to complete and publish binaries
+  wait-for-release:
+    name: Wait for Release Workflow
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'  # Only for automatic tag triggers
+    steps:
+      - name: Wait for release workflow
+        run: |
+          echo "Waiting for release workflow to complete..."
+          sleep 60  # Give workflow time to start
+
+          # Poll for release workflow completion
+          for i in {1..30}; do
+            STATUS=$(gh run list --workflow=release.yml \
+              --branch=${GITHUB_REF#refs/tags/} --limit=1 \
+              --json status --jq '.[0].status')
+            if [ "$STATUS" = "completed" ]; then
+              echo "Release workflow completed"
+              exit 0
+            fi
+            echo "Release workflow status: $STATUS (attempt $i/30)"
+            sleep 30
+          done
+
+          echo "Timeout waiting for release workflow"
+          exit 1
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   docker:
     name: Build and Push Docker Images
     runs-on: ubuntu-latest
+    needs: [wait-for-release]
+    if: always() && (needs.wait-for-release.result == 'success' || github.event_name == 'workflow_dispatch')
     environment: gcp-artifact-repo
     steps:
       - uses: actions/checkout@v5
@@ -65,6 +96,16 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest
 
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -75,3 +116,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
-# Build stage - using Chainguard's Rust image with dev tools
-FROM cgr.dev/chainguard/rust:latest-dev AS builder
+# Download pre-built binary stage
+FROM cgr.dev/chainguard/wolfi-base:latest AS downloader
 
+# Build args for version and architecture
+ARG VERSION=v0.1.0
+ARG TARGETARCH
+
+# Install curl for downloading
 USER root
-RUN apk add --no-cache openssl-dev pkgconf
-USER nonroot
+RUN apk add --no-cache curl
 
-WORKDIR /app
-
-# Copy manifests
-COPY Cargo.toml Cargo.lock ./
-
-# Copy source code
-COPY src ./src
-
-# Build the application
-RUN cargo build --release
+# Download the appropriate binary based on architecture
+RUN case "${TARGETARCH}" in \
+      amd64) ARCH_SUFFIX="amd64" ;; \
+      arm64) ARCH_SUFFIX="arm64" ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -L "https://github.com/headwind-sh/headwind/releases/download/${VERSION}/headwind-linux-${ARCH_SUFFIX}" \
+      -o /tmp/headwind && \
+    chmod +x /tmp/headwind
 
 # Runtime stage - using Chainguard's wolfi-base
 # Includes glibc, OpenSSL, and CA certificates
@@ -22,8 +25,8 @@ FROM cgr.dev/chainguard/wolfi-base:latest
 
 WORKDIR /app
 
-# Copy the binary from builder
-COPY --from=builder /app/target/release/headwind /app/headwind
+# Copy the binary from downloader
+COPY --from=downloader /tmp/headwind /app/headwind
 
 # Chainguard images run as non-root by default (UID 65532)
 # No shell, no package managers - minimal attack surface


### PR DESCRIPTION
## Summary

This PR refactors the Docker build strategy from compiling from source to downloading pre-built release binaries from GitHub releases. This solves the OpenSSL compilation issues and simplifies the build process.

## Changes

### Dockerfile
- **Replaced**: Rust builder stage with simple binary download stage
- **Downloads**: Appropriate Linux binary (amd64/arm64) from GitHub releases
- **Keeps**: Chainguard wolfi-base runtime image for minimal, secure base
- **Adds**: VERSION build arg to specify which release to use

### Docker Workflow (`.github/workflows/docker.yml`)
- **Added**: `wait-for-release` job to ensure release workflow completes first
- **Added**: Version extraction step to get tag from trigger
- **Added**: VERSION build arg passed to Docker build
- **Dependency**: Workflow now waits for release binaries to be available

## Benefits

1. **Consistency**: Uses exact same binaries that users download
2. **Speed**: No compilation needed (~7s vs several minutes)
3. **Reliability**: If release binaries work, Docker will work
4. **Simplicity**: Much simpler Dockerfile (no Rust toolchain needed)
5. **Security**: Still uses Chainguard distroless base with non-root user

## Testing

- ✅ Local build tested: `docker build --platform linux/amd64 --build-arg VERSION=v0.1.0`
- ✅ Binary downloads correctly (20.5MB)
- ✅ Image runs successfully and starts operator
- ✅ Final image size: 52.9MB (excellent for a production image)
- ✅ Multi-arch support via TARGETARCH build arg
- ✅ All pre-commit hooks passed

## Architecture

**GitHub Actions Runner**: `ubuntu-latest` (GitHub's infrastructure)
**Docker Image**: `cgr.dev/chainguard/wolfi-base:latest` (Chainguard distroless)

The ubuntu-latest runner is GitHub's VM that executes the build workflow. The actual container image uses Chainguard's secure, minimal wolfi-base.

## Breaking Changes

None - Docker images will now automatically build after release workflow completes.

Closes #78