### PR TITLE
fix: disable Docker build cache to prevent stale layer reuse

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,7 +114,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          no-cache: true
           build-args: |
             VERSION=${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Disables Docker build cache in the workflow to prevent reusing stale cached layers from the old Dockerfile that compiled from source.

## Problem

The Docker workflow was using GitHub Actions cache that contained layers from the previous Dockerfile. Even though PR #79 changed the Dockerfile to download pre-built binaries, Docker was reusing cached compilation steps, causing builds to fail with OpenSSL errors.

## Solution

**Changed**: `cache-from: type=gha` + `cache-to: type=gha,mode=max` → `no-cache: true`

This forces Docker to execute all steps fresh, ensuring the new download-based Dockerfile is used correctly.

## Testing

Once this PR is merged and the Docker workflow runs successfully with the new Dockerfile:
- First build will be slower (~2-3 minutes) but will succeed
- Can re-enable caching in a follow-up PR for faster subsequent builds

## Trade-offs

**Short-term**: Slower builds (no cache)
**Long-term**: After first successful build, we can re-enable caching

Closes #80