### PR TITLE
fix: update helm-release workflow to use docs/static/charts

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -41,27 +41,25 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-
-      - name: Copy chart index to charts/ subdirectory
+      - name: Update chart index in docs
         run: |
-          # Create charts directory if it doesn't exist
-          mkdir -p gh-pages/charts
+          # Checkout main branch
+          git fetch origin main
+          git checkout main
 
-          # Copy the index.yaml to charts/ subdirectory
+          # Create charts directory in docs/static
+          mkdir -p docs/static/charts
+
+          # Copy the index.yaml to docs/static/charts
           if [ -f index.yaml ]; then
-            cp index.yaml gh-pages/charts/index.yaml
-            echo "Copied index.yaml to charts/ subdirectory"
+            cp index.yaml docs/static/charts/index.yaml
+            echo "Copied index.yaml to docs/static/charts/"
+          else
+            echo "Warning: index.yaml not found"
+            exit 1
           fi
 
-          # Commit and push
-          cd gh-pages
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add charts/index.yaml
-          git diff --staged --quiet || git commit -m "Update Helm chart repository index"
-          git push origin gh-pages
+          # Commit and push to main
+          git add docs/static/charts/index.yaml
+          git diff --staged --quiet || git commit -m "chore: update Helm chart repository index [skip ci]"
+          git push origin main


### PR DESCRIPTION
Fixes #85

## Summary

Simplifies the Helm release workflow to work with the existing GitHub Pages deployment strategy. Instead of trying to use a separate `gh-pages` branch, the workflow now commits the chart index to `docs/static/charts/` on the main branch, which Docusaurus automatically serves as static files.

## Problem

The previous approach tried to use a `gh-pages` branch, but the repository uses workflow-based GitHub Pages deployment (github-pages environment) that builds from the `docs/` directory on main. This caused conflicts and failures.

## Solution

**Unified approach using Docusaurus static files**:
1. Chart-releaser creates GitHub releases with `.tgz` packages
2. `cr index` generates `index.yaml` from all releases
3. Index is committed to `docs/static/charts/` on main branch
4. Docusaurus deployment workflow picks it up automatically
5. Charts are served at https://headwind.sh/charts/

## Changes

- Modified `.github/workflows/helm-release.yml`:
  - Use `cr index` to generate index directly into `docs/static/charts/`
  - Commit to main branch with `[skip ci]` to prevent loops
  - Removed complex gh-pages branch logic
- Created `docs/static/charts/README.md` with usage instructions

## Benefits

- ✅ No separate gh-pages branch needed
- ✅ Works with existing Docusaurus deployment
- ✅ Single source of truth (main branch)
- ✅ Simpler workflow logic
- ✅ Chart repository and docs stay in sync

## Testing Plan

After merge:
1. ✅ Chart release workflow creates GitHub releases
2. ✅ Generates `index.yaml` and commits to `docs/static/charts/`
3. ✅ Docusaurus deployment includes the chart index
4. ✅ Chart repository accessible at https://headwind.sh/charts/

Users can then add the repository:
```bash
helm repo add headwind https://headwind.sh/charts
helm repo update
helm install headwind headwind/headwind -n headwind-system --create-namespace
```

Closes #85