### PR TITLE
fix: simplify helm-release workflow to use docs/static/charts

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -38,28 +38,32 @@ jobs:
         with:
           charts_dir: charts
           config: .github/cr.yaml
+          skip_upload: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Update chart index in docs
         run: |
-          # Checkout main branch
-          git fetch origin main
-          git checkout main
+          # Install cr (chart-releaser) CLI to generate index
+          CR_URL="https://github.com/helm/chart-releaser/releases/download/v1.6.0"
+          curl -sSL "${CR_URL}/chart-releaser_1.6.0_linux_amd64.tar.gz" | tar xz
 
-          # Create charts directory in docs/static
-          mkdir -p docs/static/charts
+          # Generate index.yaml from all GitHub releases
+          ./cr index \
+            --owner headwind-sh \
+            --git-repo headwind \
+            --charts-repo https://headwind.sh/charts \
+            --index-path ./docs/static/charts \
+            --package-path .cr-release-packages
 
-          # Copy the index.yaml to docs/static/charts
-          if [ -f index.yaml ]; then
-            cp index.yaml docs/static/charts/index.yaml
-            echo "Copied index.yaml to docs/static/charts/"
-          else
-            echo "Warning: index.yaml not found"
-            exit 1
-          fi
-
-          # Commit and push to main
+          # Commit the updated index to main branch
           git add docs/static/charts/index.yaml
-          git diff --staged --quiet || git commit -m "chore: update Helm chart repository index [skip ci]"
-          git push origin main
+
+          if git diff --staged --quiet; then
+            echo "No changes to chart index"
+          else
+            git commit -m "chore: update Helm chart repository index [skip ci]"
+            git push origin main
+            echo "Chart index updated and pushed to main"
+            echo "Charts will be available at: https://headwind.sh/charts/"
+          fi

--- a/docs/static/charts/README.md
+++ b/docs/static/charts/README.md
@@ -1,0 +1,22 @@
+# Headwind Helm Charts
+
+This directory contains the Helm chart repository index for Headwind.
+
+The chart repository is automatically updated by the helm-release workflow when changes are made to charts in the repository.
+
+## Usage
+
+Add the Helm repository:
+
+```bash
+helm repo add headwind https://headwind.sh/charts
+helm repo update
+```
+
+Install Headwind:
+
+```bash
+helm install headwind headwind/headwind -n headwind-system --create-namespace
+```
+
+For more information, see the [Helm Installation Guide](https://headwind.sh/docs/guides/helm-installation).


### PR DESCRIPTION
Fixes #85

## Summary

Simplifies the Helm release workflow to work with the existing GitHub Pages deployment strategy. Instead of trying to use a separate `gh-pages` branch, the workflow now commits the chart index to `docs/static/charts/` on the main branch, which Docusaurus automatically serves as static files.

## Problem

The previous approach tried to use a `gh-pages` branch, but the repository uses workflow-based GitHub Pages deployment (github-pages environment) that builds from the `docs/` directory on main. This caused conflicts and failures.

## Solution

**Unified approach using Docusaurus static files**:
1. Chart-releaser creates GitHub releases with `.tgz` packages
2. `cr index` generates `index.yaml` from all releases
3. Index is committed to `docs/static/charts/` on main branch
4. Docusaurus deployment workflow picks it up automatically
5. Charts are served at https://headwind.sh/charts/

## Changes

- Modified `.github/workflows/helm-release.yml`:
  - Use `cr index` to generate index directly into `docs/static/charts/`
  - Commit to main branch with `[skip ci]` to prevent loops
  - Removed complex gh-pages branch logic
- Created `docs/static/charts/README.md` with usage instructions

## Benefits

- ✅ No separate gh-pages branch needed
- ✅ Works with existing Docusaurus deployment
- ✅ Single source of truth (main branch)
- ✅ Simpler workflow logic
- ✅ Chart repository and docs stay in sync

## Testing Plan

After merge:
1. ✅ Chart release workflow creates GitHub releases
2. ✅ Generates `index.yaml` and commits to `docs/static/charts/`
3. ✅ Docusaurus deployment includes the chart index
4. ✅ Chart repository accessible at https://headwind.sh/charts/

Users can then add the repository:
```bash
helm repo add headwind https://headwind.sh/charts
helm repo update
helm install headwind headwind/headwind -n headwind-system --create-namespace
```

Closes #85