### PR TITLE
helm: remove placeholder PGP signing annotation

### DIFF
--- a/charts/headwind/Chart.yaml
+++ b/charts/headwind/Chart.yaml
@@ -41,6 +41,3 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
-  artifacthub.io/signKey: |
-    fingerprint: <placeholder>
-    url: https://headwind.sh/pgp-key.txt


### PR DESCRIPTION
## Summary
Removes the `artifacthub.io/signKey` annotation with placeholder values from Chart.yaml.

## Problem
The placeholder PGP signing annotation was appearing in the published Helm chart repository index at https://headwind.sh/charts/index.yaml, which looks unprofessional:

```yaml
artifacthub.io/signKey: |
  fingerprint: <placeholder>
  url: https://headwind.sh/pgp-key.txt
```

## Solution
Removed the entire `artifacthub.io/signKey` annotation. Chart signing is optional and can be implemented later when we're ready to set up a proper PGP signing workflow.

## Changes
- Removed lines 44-46 from `charts/headwind/Chart.yaml`

## Note
This will require a new chart release (version 0.1.1) to publish the corrected Chart.yaml without the placeholder to the Helm repository.

Closes #90