### PR TITLE
fix: correct chart-releaser download URL architecture

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -38,8 +38,10 @@ jobs:
           VERSION="1.6.1"
           OS="$(uname | tr '[:upper:]' '[:lower:]')"
           ARCH="$(uname -m)"
+          # chart-releaser uses 'amd64' instead of 'x86_64'
+          [[ "$ARCH" == "x86_64" ]] && ARCH="amd64"
           URL="https://github.com/helm/chart-releaser/releases/download"
-          wget -q "${URL}/v${VERSION}/chart-releaser_${VERSION}_${OS}_${ARCH}.tar.gz"
+          wget "${URL}/v${VERSION}/chart-releaser_${VERSION}_${OS}_${ARCH}.tar.gz"
           tar xzf "chart-releaser_${VERSION}_${OS}_${ARCH}.tar.gz"
           sudo mv cr /usr/local/bin/cr
           rm -f "chart-releaser_${VERSION}_${OS}_${ARCH}.tar.gz"


### PR DESCRIPTION
## Problem

The helm-release workflow fails with exit code 8 when trying to download chart-releaser:

```
wget -q https://github.com/helm/chart-releaser/releases/download/v1.6.1/chart-releaser_1.6.1_linux_x86_64.tar.gz
Error: Process completed with exit code 8.
```

Exit code 8 from wget = "Server error response" (404 Not Found).

## Root Cause

The workflow uses `uname -m` which returns `x86_64` on GitHub Actions runners. However, chart-releaser follows Go's architecture naming convention and uses `amd64` instead of `x86_64` in release filenames.

**Current (broken) URL:**
```
chart-releaser_1.6.1_linux_x86_64.tar.gz  ❌ 404
```

**Correct URL:**
```
chart-releaser_1.6.1_linux_amd64.tar.gz  ✅ exists
```

## Solution

Convert architecture name before constructing download URL:

```bash
ARCH="$(uname -m)"
# chart-releaser uses 'amd64' instead of 'x86_64'
[[ "$ARCH" == "x86_64" ]] && ARCH="amd64"
```

Also removed `-q` flag from wget so errors are visible if download fails.

## Testing

This PR will be tested by the helm-release workflow when merged. The workflow should now successfully install chart-releaser.

Fixes #93