### PR TITLE
fix: add --repo flag to gh run list in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
           # Poll for release workflow completion
           for i in {1..30}; do
             STATUS=$(gh run list --workflow=release.yml \
+              --repo ${{ github.repository }} \
               --branch=${GITHUB_REF#refs/tags/} --limit=1 \
               --json status --jq '.[0].status')
             if [ "$STATUS" = "completed" ]; then


### PR DESCRIPTION
## Summary

Fixes the Docker workflow's wait-for-release job failing with:
```
failed to determine base repo: fatal: not a git repository
```

## Changes

Added `--repo ${{ github.repository }}` flag to the `gh run list` command in the wait-for-release job.

## Why This Works

The `gh` CLI requires either:
1. Being run inside a git repository (requires checkout), OR  
2. An explicit `--repo` flag to know which repository to query

Using the `--repo` flag is more efficient as it doesn't require cloning the entire repository just to poll for workflow status.

## Testing

- ✅ YAML syntax validated by pre-commit hooks
- 🔄 Will be tested when next release is triggered

## Related

Fixes #97